### PR TITLE
Add a DNS record for the EC2 instance

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,10 @@ output "ec2_connect_url" {
   value = "https://${data.aws_region.current.name}.console.aws.amazon.com/ec2/v2/connect/ubuntu/${aws_instance.web.id}"
 }
 
-output "web_server_url" {
+output "web_server_ip" {
   value = "http://${aws_instance.web.public_ip}"
+}
+
+output "web_server_url" {
+  value = "http://${aws_route53_record.webserver.fqdn}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,3 +21,8 @@ variable "vpc_name" {
   default     = "strawbtest"
   description = "A name to identify the VPC"
 }
+
+variable "route53_zone" {
+  type    = string
+  default = "lucy-davinhart.sbx.hashidemos.io"
+}


### PR DESCRIPTION
Requires the existence of a Route53 Hosted Zone

As this module is written for my usage, it'll pick one of mine as the default. Everybody else will have to set their own as a parameter.

(But honestly... who else is using this module?)